### PR TITLE
feat: integrate Pragma priceFeeds for STRK/USD and ETH/USD 

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -6,6 +6,7 @@ name = "auto_swappr"
 version = "0.1.0"
 dependencies = [
  "openzeppelin",
+ "pragma_lib",
  "snforge_std",
 ]
 
@@ -114,6 +115,11 @@ source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.19.0#8d
 name = "openzeppelin_utils"
 version = "0.19.0"
 source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.19.0#8d49e8c445efd9bdc99b050c8b7d11ae5ad19628"
+
+[[package]]
+name = "pragma_lib"
+version = "1.0.0"
+source = "git+https://github.com/astraly-labs/pragma-lib?tag=2.8.2#86d7ccdc15b349b8b48d9796fc8464c947bea6e1"
 
 [[package]]
 name = "snforge_scarb_plugin"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -8,6 +8,7 @@ edition = "2023_11"
 [dependencies]
 starknet = "2.8.5"
 openzeppelin = { git = "https://github.com/OpenZeppelin/cairo-contracts.git", tag = "v0.19.0" }
+pragma_lib = { git = "https://github.com/astraly-labs/pragma-lib", tag = "2.8.2" }
 
 [dev-dependencies]
 snforge_std = { git = "https://github.com/foundry-rs/starknet-foundry", tag = "v0.33.0" }

--- a/src/autoswappr.cairo
+++ b/src/autoswappr.cairo
@@ -2,6 +2,8 @@
 // @title AutoSwappr Contract
 // @dev Implements upgradeable pattern and ownership control
 pub mod AutoSwappr {
+    use pragma_lib::abi::{IPragmaABIDispatcher, IPragmaABIDispatcherTrait};
+    use pragma_lib::types::{AggregationMode, DataType, PragmaPricesResponse};
     use crate::interfaces::iautoswappr::{IAutoSwappr, ContractInfo};
     use crate::base::types::{Route, Assets, RouteParams, SwapParams};
     use openzeppelin_upgrades::UpgradeableComponent;
@@ -25,6 +27,9 @@ pub mod AutoSwappr {
     use core::integer::{u256, u128};
     use core::num::traits::Zero;
 
+    const ETH_KEY: felt252 = 'ETH/USD';
+    const STRK_KEY: felt252 = 'STRK/USD';
+
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
 
@@ -44,6 +49,7 @@ pub mod AutoSwappr {
         fees_collector: ContractAddress,
         avnu_exchange_address: ContractAddress,
         fibrous_exchange_address: ContractAddress,
+        oracle_address: ContractAddress,
         supported_assets: Map<ContractAddress, bool>,
         autoswappr_addresses: Map<ContractAddress, bool>,
         #[substorage(v0)]
@@ -100,6 +106,7 @@ pub mod AutoSwappr {
         fees_collector: ContractAddress,
         avnu_exchange_address: ContractAddress,
         fibrous_exchange_address: ContractAddress,
+        oracle_address: ContractAddress,
         _strk_token: ContractAddress,
         _eth_token: ContractAddress,
         owner: ContractAddress,
@@ -110,6 +117,7 @@ pub mod AutoSwappr {
         self.fibrous_exchange_address.write(fibrous_exchange_address);
         self.avnu_exchange_address.write(avnu_exchange_address);
         self.fibrous_exchange_address.write(fibrous_exchange_address);
+        self.oracle_address.write(oracle_address);
         self.ownable.initializer(owner);
         self.supported_assets.entry(_strk_token).write(true);
         self.supported_assets.entry(_eth_token).write(true);
@@ -220,6 +228,14 @@ pub mod AutoSwappr {
             self._fibrous_swap(routeParams, swapParams,);
         }
 
+        fn get_strk_usd_price(self: @ContractState) -> (u128, u32) {
+            self.get_asset_price_median(DataType::SpotEntry(STRK_KEY))
+        }
+
+        fn get_eth_usd_price(self: @ContractState) -> (u128, u32) {
+            self.get_asset_price_median(DataType::SpotEntry(ETH_KEY))
+        }
+
         fn set_operator(ref self: ContractState, address: ContractAddress) {
             assert(get_caller_address() == self.ownable.owner(), Errors::NOT_OWNER);
             assert(
@@ -301,6 +317,15 @@ pub mod AutoSwappr {
             };
 
             fibrous.swap(routeParams, swapParams);
+        }
+
+        fn get_asset_price_median(self: @ContractState, asset: DataType) -> (u128, u32) {
+            let oracle_dispatcher = IPragmaABIDispatcher {
+                contract_address: self.oracle_address.read()
+            };
+            let output: PragmaPricesResponse = oracle_dispatcher
+                .get_data(asset, AggregationMode::Median(()));
+            return (output.price, output.decimals);
         }
 
         fn collect_fees(ref self: ContractState) {}

--- a/src/interfaces/iautoswappr.cairo
+++ b/src/interfaces/iautoswappr.cairo
@@ -34,5 +34,7 @@ pub trait IAutoSwappr<TContractState> {
     fn set_operator(ref self: TContractState, address: ContractAddress);
     fn remove_operator(ref self: TContractState, address: ContractAddress);
     fn is_operator(self: @TContractState, address: ContractAddress) -> bool;
+    fn get_strk_usd_price(self: @TContractState) -> (u128, u32);
+    fn get_eth_usd_price(self: @TContractState) -> (u128, u32);
 }
 

--- a/tests/test_autoswapper.cairo
+++ b/tests/test_autoswapper.cairo
@@ -35,6 +35,10 @@ pub fn OPERATOR() -> ContractAddress {
     contract_address_const::<'OPERATOR'>()
 }
 
+pub fn ORACLE_ADDRESS() -> ContractAddress {
+    contract_address_const::<0x2a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b>()
+}
+
 // *************************************************************************
 //                              SETUP
 // *************************************************************************
@@ -75,6 +79,7 @@ fn __setup__() -> (ContractAddress, IERC20Dispatcher, IERC20Dispatcher) {
     FEE_COLLECTOR_ADDR().serialize(ref autoSwappr_constructor_calldata);
     AVNU_ADDR().serialize(ref autoSwappr_constructor_calldata);
     FIBROUS_ADDR().serialize(ref autoSwappr_constructor_calldata);
+    ORACLE_ADDRESS().serialize(ref autoSwappr_constructor_calldata);
     strk_contract_address.serialize(ref autoSwappr_constructor_calldata);
     eth_contract_address.serialize(ref autoSwappr_constructor_calldata);
     OWNER().serialize(ref autoSwappr_constructor_calldata);
@@ -187,4 +192,26 @@ fn test_is_operator() {
 
     assert(autoSwappr_dispatcher.is_operator(USER()) == true, 'is operator');
     stop_cheat_caller_address_global();
+}
+
+#[test]
+#[fork(url: "https://starknet-mainnet.public.blastapi.io/rpc/v0_7", block_number: 996491)]
+fn test_contract_fetches_eth_usd_price_correctly() {
+    let (autoSwappr_contract_address, _, _) = __setup__();
+    let autoswappr_dispatcher = IAutoSwapprDispatcher {
+        contract_address: autoSwappr_contract_address
+    };
+    let (eth_usd_price, decimals) = autoswappr_dispatcher.get_eth_usd_price();
+    println!("The eth/usd price is {} with {} decimals", eth_usd_price, decimals);
+}
+
+#[test]
+#[fork(url: "https://starknet-mainnet.public.blastapi.io/rpc/v0_7", block_number: 996491)]
+fn test_contract_fetches_strk_usd_price_correctly() {
+    let (autoSwappr_contract_address, _, _) = __setup__();
+    let autoswappr_dispatcher = IAutoSwapprDispatcher {
+        contract_address: autoSwappr_contract_address
+    };
+    let (strk_usd_price, decimals) = autoswappr_dispatcher.get_strk_usd_price();
+    println!("The strk/usd price is {} with {} decimals", strk_usd_price, decimals);
 }

--- a/tests/test_avnu_swap.cairo
+++ b/tests/test_avnu_swap.cairo
@@ -115,6 +115,10 @@ fn EXCHANGE_ETH_USDC() -> ContractAddress {
     >() // myswap: CL AMM swap
 }
 
+pub fn ORACLE_ADDRESS() -> ContractAddress {
+    contract_address_const::<0x2a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b>()
+}
+
 
 const AMOUNT_TO_SWAP_STRK: u256 = 1000000000000000000; // 1 STRK
 const AMOUNT_TO_SWAP_ETH: u256 = 200000000000000; // 0.0002 ETH 
@@ -389,6 +393,7 @@ fn __setup__() -> IAutoSwapprDispatcher {
         FEE_COLLECTOR,
         AVNU_EXCHANGE_ADDRESS().into(),
         FIBROUS_EXCHANGE_ADDRESS().into(),
+        ORACLE_ADDRESS().into(),
         STRK_TOKEN_ADDRESS().into(),
         ETH_TOKEN_ADDRESS().into(),
         OWNER,

--- a/tests/test_fibrous_swap.cairo
+++ b/tests/test_fibrous_swap.cairo
@@ -65,6 +65,10 @@ fn USDC_TOKEN() -> IERC20Dispatcher {
     IERC20Dispatcher { contract_address: USDC_TOKEN_ADDRESS() }
 }
 
+pub fn ORACLE_ADDRESS() -> ContractAddress {
+    contract_address_const::<0x2a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b>()
+}
+
 const AMOUNT_TO_SWAP_STRK: u256 = 1000000000000000000; // 1 STRK
 const AMOUNT_TO_SWAP_ETH: u256 = 10000000000000000; // 0.01 ETH 
 const MIN_RECEIVED_STRK_TO_STABLE: u256 = 550000; // 0.55 USD stable coin (USDC or USDT)
@@ -240,6 +244,7 @@ fn __setup__() -> IAutoSwapprDispatcher {
         FEE_COLLECTOR,
         AVNU_EXCHANGE_ADDRESS().into(),
         FIBROUS_EXCHANGE_ADDRESS().into(),
+        ORACLE_ADDRESS().into(),
         STRK_TOKEN_ADDRESS().into(),
         ETH_TOKEN_ADDRESS().into(),
         OWNER,


### PR DESCRIPTION
## Description

This feature integrates with [Pragma Oracle](https://docs.pragma.build/v1/Resources/data-feeds/consuming-data) to retrieve STRK to USD and ETH to USD prices using [`get_data_median`](https://docs.pragma.build/v1/Resources/data-feeds/consuming-data#function-get_data_median)

## Related Issue(s)
Closes #46 
## Checklist:

- [x] Read the [contributing docs](../CONTRIBUTING.md) (if this is your first contribution)
- [x] Verified this is not a duplicate of any existing pull request

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)