### PR TITLE
doc: add local `RPC_URL` env variable in README

### DIFF
--- a/.github/workflows/test_contracts.yml
+++ b/.github/workflows/test_contracts.yml
@@ -1,4 +1,4 @@
-name: Build and test AutoSwap contracts
+ame: Build and test AutoSwap contracts
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 env:
-  RPC_URL: ${{ secrets.RPC_URL }}
+  RPC_URL: ${{ vars.RPC_URL }}
 
 jobs:
   build:
@@ -26,7 +26,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    # environment: autoswappr
+    environment: autoswappr
     name: tests
     steps:
       - name: Checkout code
@@ -44,7 +44,7 @@ jobs:
 
       - name: Substitute RPC URL in Scarb.toml
         run: |
-          sed -i "s|\$RPC_URL|$RPC_URL|g" Scarb.toml
+            sed -i "s|\$RPC_URL|$RPC_URL|g" Scarb.toml
 
       - name: Run tests
         run: snforge test

--- a/README.md
+++ b/README.md
@@ -74,11 +74,27 @@ scarb build
 
 ## Testing
 
-Run the test suite using Starknet Foundry:
+Before running the tests,
+1. Ensure the `RPC_URL` environment variable is set locally in your shell:
+```bash
+export RPC_URL=https://starknet-mainnet.public.blastapi.io/rpc/v0_7
+```
 
+2. Then save and reload your shell:
+```bash
+source ~/.zshrc
+```
+
+3. After setting the variable, verify it in your shell; this should output your rpc url in your terminal:
+```bash
+echo $RPC_URL
+```
+
+4. Proceed to run snforge test:
 ```bash
 snforge test
 ```
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ AutoSwappr is built on Starknet and implements:
 
 ## Prerequisites
 
-To set up and run the project locally, ensure you have the following installed:
+To set up and run the project locally, ensure you have [the following installed](https://foundry-rs.github.io/starknet-foundry/getting-started/installation.html#install-rust-version--1801):
 
 - [**Starknet Foundry**](https://foundry-rs.github.io/starknet-foundry/index.html)
 - [**Scarb**](https://docs.swmansion.com/scarb/download.html)
@@ -103,8 +103,9 @@ We welcome contributions! Please follow these steps:
 1. Fork the repository
 2. Create your feature branch (git checkout -b revoke-allowance)
 3. Commit your changes (git commit -m 'test: revoke allowance')
-4. Push to the branch (git push origin revoke-allowance)
-5. Open a Pull Request
+4. Run `bash test_local.sh` to ensure you have a consistent environment with our workflow actions; (Please make you have successfully set `RPC_URL` with this command - `export RPC_URL=https://starknet-mainnet.public.blastapi.io/rpc/v0_7`). All tests must pass locally before proceeding to the next action
+5. Push to the branch (git push origin revoke-allowance)
+6. Open a Pull Request
 
 
 

--- a/test_local.sh
+++ b/test_local.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Build the project
+scarb build || exit 1
+
+# Substitute RPC_URL
+sed -i "s|\$RPC_URL|$RPC_URL|g" Scarb.toml
+
+# Run tests
+snforge test || exit 1
+
+# Restore Scarb.toml
+git checkout Scarb.toml
+
+echo "Local test completed successfully!"


### PR DESCRIPTION
## Description
- Resolves the issue where the absence of local `RPC_URL` environment variable triggers `[ERROR] environment variable not found` error 
- Update the `README` to highlight the need for setting the `RPC_URL` environment variable locally in the shell before proceeding to run tests.

## Related Issue(s)

Closes #57 
## Checklist:

- [x] Read the [contributing docs](../CONTRIBUTING.md) (if this is your first contribution)
- [x] Verified this is not a duplicate of any existing pull request

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)